### PR TITLE
Fix compilation for PHP 7.3

### DIFF
--- a/php_git2.c
+++ b/php_git2.c
@@ -1062,11 +1062,11 @@ PHP_MINIT_FUNCTION(git2)
 
 	INIT_CLASS_ENTRY(ce, "Git2ODBBackendForeachCallback", 0);
 	php_git2_odb_backend_foreach_callback_class_entry = zend_register_internal_class(&ce TSRMLS_CC);
-    #if PHP_MINOR_VERSION < 3
-    zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC);
-    #else
-    zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC, php_git2_odb_backend_foreach_callback_class_entry->type != ZEND_USER_CLASS);
-    #endif
+#if PHP_MINOR_VERSION < 3
+	zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC);
+#else
+	zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC, php_git2_odb_backend_foreach_callback_class_entry->type != ZEND_USER_CLASS);
+#endif
 	php_git2_odb_backend_foreach_callback_class_entry->create_object = php_git2_odb_backend_foreach_callback_new;
 
 	git2_resource_handle = zend_register_list_destructors_ex(destruct_git2, NULL, PHP_GIT2_RESOURCE_NAME, module_number);

--- a/php_git2.c
+++ b/php_git2.c
@@ -1062,7 +1062,11 @@ PHP_MINIT_FUNCTION(git2)
 
 	INIT_CLASS_ENTRY(ce, "Git2ODBBackendForeachCallback", 0);
 	php_git2_odb_backend_foreach_callback_class_entry = zend_register_internal_class(&ce TSRMLS_CC);
-	zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC);
+    #if PHP_MINOR_VERSION < 3
+    zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC);
+    #else
+    zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC, php_git2_odb_backend_foreach_callback_class_entry->type != ZEND_USER_CLASS);
+    #endif
 	php_git2_odb_backend_foreach_callback_class_entry->create_object = php_git2_odb_backend_foreach_callback_new;
 
 	git2_resource_handle = zend_register_list_destructors_ex(destruct_git2, NULL, PHP_GIT2_RESOURCE_NAME, module_number);


### PR DESCRIPTION
I've tried to compile this library under Debian Buster which have PHP 7.3,
```
PHP 7.3.4-2 (cli) (built: Apr 13 2019 19:05:48) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.4, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.3.4-2, Copyright (c) 1999-2018, by Zend Technologies
```

but got following error:

```
/home/src/php-git/php_git2.c: In function 'zm_startup_git2':
/home/src/php-git/php_git2.c:1065:2: error: too few arguments to function 'zend_register_class_alias_ex'
  zend_register_class_alias_ex(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"), sizeof(ZEND_NS_NAME("Git2\\ODB\\Backend", "ForeachCallback"))-1, php_git2_odb_backend_foreach_callback_class_entry TSRMLS_CC);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/php/20180731/main/php.h:38,
                 from /home/src/php-git/php_git2.h:32,
                 from /home/src/php-git/php_git2.c:26:
/usr/include/php/20180731/Zend/zend_API.h:289:14: note: declared here
 ZEND_API int zend_register_class_alias_ex(const char *name, size_t name_len, zend_class_entry *ce, int persistent);
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:195: php_git2.lo] Error 1
```

This commit is based on similar problem in other project:
https://github.com/swoole/phpx/pull/58/commits/cfb723fc5cf5013cae30a18faa241b1a70d9bd37

After applying this change I could compile succesfuly.